### PR TITLE
Snackbar context `onClose` event bugfix

### DIFF
--- a/client/src/context/useSnackbarContext.tsx
+++ b/client/src/context/useSnackbarContext.tsx
@@ -24,7 +24,7 @@ export const SnackBarProvider: FunctionComponent = ({ children }): JSX.Element =
     setOpen(false);
   }, []);
 
-  const snackbarHandleClose = useCallback((event: SyntheticEvent, reason: SnackbarCloseReason) => {
+  const snackbarHandleClose = useCallback((event: SyntheticEvent | Event, reason: SnackbarCloseReason) => {
     if (reason === 'clickaway') return;
     setOpen(false);
   }, []);


### PR DESCRIPTION
There is a change in `5.2.2` release of `@mui/material` that can lead to a `Typescript` error similar to:

![snackbarError](https://user-images.githubusercontent.com/70963670/148518843-356d3b8c-8f24-4552-be72-bfe9ea3472d3.png)

The change introduced is seen below:

<img width="632" alt="onclose-event-typing-changes" src="https://user-images.githubusercontent.com/70963670/148517931-f1e11009-9727-489f-bc44-4d6c6395d643.png">

[relevant mui release](https://github.com/mui-org/material-ui/releases/tag/v5.2.2)
[relevant pull](https://github.com/mui-org/material-ui/pull/29852)
 
Suggested changes in this pull upgrade the material ui package versions and fix the typing error introduced with the newer releases.
